### PR TITLE
Change dependabot config to only update lock file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
     directory: "/frontend/webapp"
     schedule:
       interval: "daily"
+    # Only create pull requests to update lockfiles. 
+    # Ignore any new versions that would require package manifest changes.
+    versioning-strategy: lockfile-only
     # Prefix all commit messages with "Frontend"
     # include a list of updated dependencies
     commit-message:


### PR DESCRIPTION
Major version upgrade will break the code

*Issue #, if available:*

*Description of changes:*
Change dependabot config to only update lock file

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
